### PR TITLE
server: force pull at startup to catch up

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,7 @@ github_webhook_service_name: '{{ github_webhook_service_user }}-webhook'
 github_webhook_home: '/home/{{ github_webhook_service_user }}'
 github_webhook_venv_path: '{{ github_webhook_home }}/venv'
 github_webhook_script_dir: '{{ github_webhook_home }}/webhook'
+github_webhook_log_level: 'info'
 github_webhook_addr: 'localhost'
 github_webhook_port: 9090
 github_webhook_dependencies:

--- a/files/server.py
+++ b/files/server.py
@@ -26,6 +26,7 @@ class ManagedRepo:
         self.path = dest_path
         self._init()
         self._checkout()
+        self.force_pull()
 
     def _init(self):
         self.repo = Repo.init(self.path)
@@ -73,10 +74,12 @@ class ManagedRepo:
         return self.repo.head.reset(commit=self.remote_ref, working_tree=True)
 
     def force_pull(self):
+        log.debug('Resetting repo from: %s', self.commit)
         commit_before = self.commit
         self.fetch()
         self.reset()
         commit_after = self.commit
+        log.debug('Reset repo to: %s', commit_after)
         return (commit_before, commit_after)
 
 

--- a/templates/webhook.service.j2
+++ b/templates/webhook.service.j2
@@ -8,6 +8,7 @@ After=docker.service
 [Service]
 User={{ github_webhook_service_user }}
 ExecStart={{ github_webhook_script_dir }}/server.py \
+    --log-level={{ github_webhook_log_level }} \
     --port={{ github_webhook_port }} \
     --repo-url={{ github_webhook_repo_url | mandatory }} \
     --repo-branch={{ github_webhook_repo_branch | mandatory }} \


### PR DESCRIPTION
If a service or host was down webhook service should catch up with branch changes that happened while it was down.