### PR TITLE
webhook-server: add support for broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ github_webhook_ssh_key: '-----BEGIN OPENSSH PRIVATE KEY-----\n...'
 github_webhook_service_user: 'repouser'
 github_webhook_user_additional_groups: ['docker']
 github_webhook_service_user_uid: 1500
+github_webhook_instances:
+  - 'node-01.do-ams3.proxy.test'
+  - 'node-02.do-ams3.proxy.test'
 ```
 Explanations:
 
@@ -32,3 +35,4 @@ Explanations:
 * `github_wehbook_service_user_groups` - Modify list of groups of service user.
 * `github_webhook_service_user_uid` - Change UID of service user to match repo user.
 * `github_webhook_post_command` - Command to execute after webhook request is received.
+* `github_webhook_instances` - List of all webhook instances the webhook request should go to.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ github_webhook_port: 9090
 github_webhook_dependencies:
   - 'python3-flask'
   - 'python3-git'
+  - 'python3-aiohttp'
+  - 'python3-asgiref'
+github_webhook_instances: []
 
 # Optional command to run after repo update.
 #github_webhook_post_command: '/usr/local/bin/handle_repo_update.sh --verbose'

--- a/files/webhook.py
+++ b/files/webhook.py
@@ -9,30 +9,36 @@ import hmac
 import logging
 import json
 import six
+import requests
+import aiohttp
+import asyncio
 from flask import abort, request
 
 
 class Webhook(object):
     """
-    Construct a webhook on the given :code:`app`.
+    Construct a webhook on the given :code:app.
 
     :param app: Flask app that will host the webhook
     :param endpoint: the endpoint for the registered URL rule
     :param secret: Optional secret, used to authenticate the hook comes from Github
+    :param broadcast_instances: Optional list of other instances where the webhook request should be sent to
     """
 
-    def __init__(self, app=None, endpoint="/postreceive", secret=None):
+    def __init__(self, app=None, endpoint="/postreceive", secret=None, broadcast_instances=[]):
         self.app = app
         self.secret = secret
+        self.endpoint = endpoint
+        self.broadcast_instances = broadcast_instances
+        self._logger = app.logger if app else logging.getLogger("webhook") 
         if app is not None:
             self.init_app(app, endpoint, secret)
 
     def init_app(self, app, endpoint="/postreceive", secret=None):
         self._hooks = collections.defaultdict(list)
-        self._logger = logging.getLogger("webhook")
         if secret is not None:
             self.secret = secret
-        app.add_url_rule(rule=endpoint, endpoint=endpoint, view_func=self._postreceive, methods=["POST"])
+        app.add_url_rule(rule=endpoint, endpoint=endpoint, view_func=self._post_receive, methods=["POST"])
 
     @property
     def secret(self):
@@ -63,21 +69,32 @@ class Webhook(object):
 
         return hmac.new(self._secret, request.get_data(), hashlib.sha1).hexdigest() if self._secret else None
 
-    def _postreceive(self):
-        """Callback from Flask"""
+    async def _post_receive(self):
+        """Callback from Flask for direct webhook request"""
+
+        if self.broadcast_instances and 'X-Forwarded-By' not in request.headers:
+            await self._forward_to_instances()
+        else:
+            self._process_request()
+        return "", 204
+
+
+    def _process_request(self):
+        """Process the webhook request and execute local hooks"""
 
         digest = self._get_digest()
 
         if digest is not None:
-            sig_parts = _get_header("X-Hub-Signature").split("=", 1)
+            sig_parts = self._get_header("X-Hub-Signature").split("=", 1)
             if not isinstance(digest, six.text_type):
                 digest = six.text_type(digest)
 
             if len(sig_parts) < 2 or sig_parts[0] != "sha1" or not hmac.compare_digest(sig_parts[1], digest):
+                self._logger.error(f"Invalid signature {sig_parts}!")
                 abort(400, "Invalid signature")
 
-        event_type = _get_header("X-Github-Event")
-        content_type = _get_header("content-type")
+        event_type = self._get_header("X-Github-Event")
+        content_type = self._get_header("content-type")
         data = (
             json.loads(request.form.to_dict(flat=True)["payload"])
             if content_type == "application/x-www-form-urlencoded"
@@ -85,23 +102,51 @@ class Webhook(object):
         )
 
         if data is None:
+            self._logger.error(f"Request body must contain json!")
             abort(400, "Request body must contain json")
 
-        self._logger.info("%s (%s)", _format_event(event_type, data), _get_header("X-Github-Delivery"))
+        self._logger.info("%s (%s)", _format_event(event_type, data), self._get_header("X-Github-Delivery"))
 
         for hook in self._hooks.get(event_type, []):
             hook(data)
 
-        return "", 204
+    async def _forward_to_instances(self):
+        """Forward the request to all instances in the broadcast_instances list asynchronously"""
 
+        async with aiohttp.ClientSession() as session:
+            tasks = []
+            for instance in self.broadcast_instances:
+                task = self._forward_request(session, instance)
+                tasks.append(task)
+            await asyncio.gather(*tasks)
 
-def _get_header(key):
-    """Return message header"""
+    async def _forward_request(self, session, instance):
+        """Forward the request to a single instance asynchronously"""
 
-    try:
-        return request.headers[key]
-    except KeyError:
-        abort(400, "Missing header: " + key)
+        try:
+            async with session.request(
+                method=request.method,
+                url=f"http://{instance}/{self.endpoint}",
+                headers={
+                    **{k: v for k, v in request.headers.items() if k.lower() != 'host'},
+                    "X-Forwarded-By": "webhook-server"
+                },
+                data=request.get_data(),
+                allow_redirects=False,
+            ) as response:
+                if response.status != 204:
+                    self._logger.error(f"Failed to forward request to {instance}. Status Code: {response.status}")
+        except aiohttp.ClientError as e:
+            self._logger.error(f"Error forwarding request to {instance}: {e}")
+
+    def _get_header(self, key):
+        """Return message header"""
+
+        try:
+            return request.headers[key]
+        except KeyError:
+            self._logger.error(f"Missing header {key}")
+            abort(400, "Missing header: " + key)
 
 
 EVENT_DESCRIPTIONS = {

--- a/templates/webhook.service.j2
+++ b/templates/webhook.service.j2
@@ -13,6 +13,9 @@ ExecStart={{ github_webhook_script_dir }}/server.py \
     --port={{ github_webhook_port }} \
     --repo-url={{ github_webhook_repo_url | mandatory }} \
     --repo-branch={{ github_webhook_repo_branch | mandatory }} \
+{% for instance in github_webhook_instances %}
+    --broadcast-instances='{{ instance }}' \
+{% endfor %}
 {% if github_webhook_post_command is defined %}
     --post-command='{{ github_webhook_post_command | mandatory }}' \
 {% endif %}


### PR DESCRIPTION
### Why introducing this change
This feature is useful when there are multiple webhook servers for a single repo and we want to deliver github webhook request to all of them. Most likely there will be a load balancer in front of the instances, so only one instance will receive webhook request. With this change request will be distributed to other instances as well.

### Why async requests
Github has timeout for webhook request set to 10s, if we do everything sequentially we will reach timeout. With async requests we can try to avoid the timeout, although even with them the timeouts can be reached.
We can see here an example of request which timed out:
![Screenshot from 2025-02-13 10 51 45](https://github.com/user-attachments/assets/3399d4c3-0dfc-445c-9a67-4ecca5477039)

And here an example of request that got a response in time:
![Screenshot from 2025-02-13 10 51 58](https://github.com/user-attachments/assets/fb268135-fcaf-491f-94f9-31e2034a07e0)

Notice how the successfull request took 8.7 seconds(10s is the timeout). The fact is, in this example, the requests are being delivered to Hong Kong, Central US and EU instances so the latency between them makes a difference. We could potentially return immediately 204 status code and do the pulling of the new code changes in the background. That would also mean we are accepting a potential risk there would be a failure when pulling changes that we wouldn't know anything about.

Referenced issue: https://github.com/status-im/infra-proxy/issues/13